### PR TITLE
Holding back cloud-init to prevent setup error

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -24,6 +24,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 heading 'updating + upgrading apt'
 
+apt-mark hold cloud-init
 apt-get update
 apt-get upgrade -y
 apt-get install -y gnupg2 software-properties-common curl # we need this first to setup new repos


### PR DESCRIPTION
https://www.digitalocean.com/community/questions/why-cloud-init-is-kept-back-in-a-new-droplet-with-ubuntu-16-04-while-doing-an-apt-upgrade